### PR TITLE
Add "Install with Herd" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Laravel + Vue Starter Kit + Modern PHP Tooling
 
+<a href="https://herd.laravel.com/new?starter-kit=shipfastlabs/modern-vue-starter-kit"><img src="https://img.shields.io/badge/Install%20with%20Herd-f55247?logo=laravel&logoColor=white"></a>
+
 ## Introduction
 
 Our Vue starter kit provides a robust, modern starting point for building Laravel applications with a Vue frontend using [Inertia](https://inertiajs.com).


### PR DESCRIPTION
Laravel Herd 1.18.0 was just released which allows users to open up the site wizard with one-click, having your custom starter kit pre-filled.
This makes it even easier for people to use this custom starter kit.

![CleanShot 2025-03-11 at 11 50 07@2x](https://github.com/user-attachments/assets/78e7cc21-9c1a-4f6b-91f0-bfd6ce97eb16)
